### PR TITLE
Ensures `evt.from` contains cloned element before trying to remove it

### DIFF
--- a/angular-legacy-sortable.js
+++ b/angular-legacy-sortable.js
@@ -115,7 +115,10 @@
 								if (evt.clone) {
 									removed = angular.copy(removed);
 									prevItems.splice(Sortable.utils.index(evt.clone, sortable.options.draggable), 0, prevItems.splice(oldIndex, 1)[0]);
-									evt.from.removeChild(evt.clone);
+
+									if (evt.from.contains(evt.clone)) {
+										evt.from.removeChild(evt.clone);
+									}
 								}
 								else {
 									prevItems.splice(oldIndex, 1);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/SortableJS/angular-legacy-sortablejs#readme",
   "peerDependencies": {
-    "sortablejs": "~1.4.0" 
+    "sortablejs": "~1.5.x" 
   }
 }


### PR DESCRIPTION
This should close #26.