### PR TITLE
Correctly determine if element should be moved or cloned

### DIFF
--- a/angular-legacy-sortable.js
+++ b/angular-legacy-sortable.js
@@ -113,7 +113,7 @@
 
 								removed = prevItems[oldIndex];
 
-								if (evt.clone) {
+								if (Sortable.active && Sortable.active.lastPullMode === 'clone') {
 									removed = angular.copy(removed);
 									prevItems.splice(Sortable.utils.index(evt.clone, sortable.options.draggable), 0, prevItems.splice(oldIndex, 1)[0]);
 


### PR DESCRIPTION
This is a fix for issue #34 
It seems that `evt.clone` is always defined for onAdd events. This PR changes the logic to check `Sortable.active.lastPullMode === 'clone'` which I believe is the most reliable way to determine if the add was a clone or simply a move.