### PR TITLE
Expose parent scope to event handlers

### DIFF
--- a/angular-legacy-sortable.js
+++ b/angular-legacy-sortable.js
@@ -20,6 +20,8 @@
 })(function (angular, Sortable) {
 	'use strict';
 
+	// Use default import if available
+	Sortable = Sortable.default || Sortable;
 
 	/**
 	 * @typedef   {Object}        ngSortEvent

--- a/angular-legacy-sortable.js
+++ b/angular-legacy-sortable.js
@@ -92,7 +92,8 @@
 								models: source,
 								oldIndex: evt.oldIndex,
 								newIndex: evt.newIndex,
-								originalEvent: evt
+								originalEvent: evt,
+								scope: scope.$parent
 							});
 						}
 


### PR DESCRIPTION
This will be a contrived example but my use case is:

```html
<div ng-repeat="question in $ctrl.questions">
    <div ng-sortable="$ctrl.sortableOptions">
        <div ng-repeat="answer in question.answers">
            {{answer}}
        </div>
    </div>
</div>
```

```js
this.sortableOptions = {
    onEnd: ({ scope: { question } }) => {
       this.saveQuestion(question);
    },
};
```
This does feel hacky but without it, I'm not sure how to know which question had the sortable that just changed. I suppose making a nested component would make the scope available but I've got a giant component I wasn't intending on refactoring right now.

Other libraries (such as [angular-ui-sortable](https://github.com/angular-ui/ui-sortable#attributes-for-event-handling)) use attributes for event handlers where you can pass an expression from the template to do this.

I'm just trying to get off jQuery :)