### PR TITLE
fix: update the way SortableJS is imported into the library

### DIFF
--- a/angular-legacy-sortable.js
+++ b/angular-legacy-sortable.js
@@ -20,6 +20,8 @@
 })(function (angular, Sortable) {
 	'use strict';
 
+	// Use default import if available
+	Sortable = Sortable.default || Sortable;
 
 	/**
 	 * @typedef   {Object}        ngSortEvent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-legacy-sortablejs-maintained",
-  "version": "0.6.2",
+  "version": "1.0.0",
   "description": "Angular (legacy) directive for SortableJS.",
   "main": "angular-legacy-sortable.js",
   "scripts": {


### PR DESCRIPTION
This is due to a breaking change SortableJS/Sortable#1728, which causes https://github.com/SortableJS/angular-legacy-sortablejs/ to imports SortableJS incorrectly after versions 1.10.0, which leads to it not finding Sortablejs.create.

See: 
![Screenshot 2020-06-22 at 10 59 47 AM](https://user-images.githubusercontent.com/22133008/85244522-8002da80-b477-11ea-811a-378c569cd64e.png)

This fix is obtained from https://github.com/SortableJS/angular-legacy-sortablejs/pull/53, but since the repo seems to now be unmaintained, I've decided to fork that repo to fix that issue.
